### PR TITLE
Fixed the lulu math me command, since iGoogle no longer works.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "soupselect": ">= 0.2.0",
     "htmlparser": ">= 1.7.6",
     "jsdom": ">= 0.2.14",
-    "xml2js": ">= 0"
+    "xml2js": ">= 0",
+    "ntwitter": ">= 0.5.0", //required by the hubot-scripts
+    "mathjs": ">= 1.5.0", //for 'lulu math me ...'
   },
 
   "engines": {

--- a/scripts/math.coffee
+++ b/scripts/math.coffee
@@ -4,19 +4,8 @@
 # Commands:
 #   hubot math me <expression> - Calculate the given expression.
 #   hubot convert me <expression> to <units> - Convert expression to given units.
+
+math = require('mathjs')
 module.exports = (robot) ->
   robot.respond /(calc|calculate|convert|math)( me)? (.*)/i, (msg) ->
-    msg
-      .http('http://www.google.com/ig/calculator')
-      .query
-        hl: 'en'
-        q: msg.match[3]
-      .headers
-        'Accept-Language': 'en-us,en;q=0.5',
-        'Accept-Charset': 'utf-8',
-        'User-Agent': "Mozilla/5.0 (X11; Linux x86_64; rv:2.0.1) Gecko/20100101 Firefox/4.0.1"
-      .get() (err, res, body) ->
-        # Response includes non-string keys, so we can't use JSON.parse here.
-        json = eval("(#{body})")
-        msg.send json.rhs || 'Could not compute.'
-
+    msg.send math.eval(msg.match[3])


### PR DESCRIPTION
I was playing with lulu and noticed that `lulu math me` doesn't work.  That bothered me, so I checked the code and saw that it referred to iGoogle, which is as dead as Google Reader now.  I replaced the old command with one that uses [Math.js](http://mathjs.org/) to evaluate expressions.  It still does conversions and everything!

I actually don't know anything about Coffeescript, Node, Heroku, Hubot, etc...  I just know that this code worked on my machine.  So view my PR with a grain of salt.
