### PR TITLE
Adding a script to have lulu respond to identity requests

### DIFF
--- a/scripts/identify.coffee
+++ b/scripts/identify.coffee
@@ -1,0 +1,14 @@
+# Description:
+#   An auto-responder for identity-like queries
+#
+# Commands:
+#   listens for "who is " followed by the bot name
+bot_name = process.env.HUBOT_IRC_NICK or 'hubot'
+
+identity_request = new RegExp("((who)|(what)).* is " + bot_name, "i")
+
+bot_location = "https://github.com/cwruacm/lulu"
+
+module.exports = (robot) ->
+  robot.hear identity_request, (msg) ->
+    msg.send "I am #{bot_name}. My source lives at " + bot_location


### PR DESCRIPTION
Bringing in my script for lulu to reference its git repo when called: copied from thomasrussellmurphy/personal_hubot and then edited to suit lulu.

The bot responds to `RegExp("((who)|(what)).* is " + bot_name, "i")` with its name and a link to this repository.
