### PR TITLE
Fixing jsdom to 3.1.2 due to incompatibility with Node.js in 4.0.0+

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "hubot-irc": ">= 0.1.9",
     "hubot-scripts": "git://github.com/github/hubot-scripts.git#master",
     "hubot-tell": "*",
-    "jsdom": ">= 0.2.14",
+    "jsdom": "== 3.1.2",
     "mathjs": ">= 1.5.0",
     "ntwitter": ">= 0.5.0",
     "optparse": "1.0.3",


### PR DESCRIPTION
Simply having a fixed version number for jsdom. Probably should consider using newer jsdom, but it requires io.js, which we don't currently have here.
