### PR TITLE
Adding hubot-redis-brain to the package for ease of deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "hubot": ">= 2.5.1",
     "hubot-google-translate": ">= 0.2.0",
     "hubot-irc": ">= 0.1.9",
+    "hubot-redis-brain": ">= 0",
     "hubot-scripts": "git://github.com/github/hubot-scripts.git#master",
     "hubot-shipit": "^0.2.0",
     "hubot-tell": "*",


### PR DESCRIPTION
@brenns10 forgot it, so this should prevent the dependency from being missing when starting lulu.
