### PR TITLE
Now that hubot-youtube is functional again, time to use it!

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ keys/passwords/tokens that lives on irc.case.edu.
 - `HUBOT_IRC_SERVER`
 - `HUBOT_REDMINE_BASE_URL`
 - `HUBOT_REDMINE_TOKEN`
+- `HUBOT_YOUTUBE_API_KEY`
+- `HUBOT_YOUTUBE_DETERMINISTIC_RESULTS` (optional flag)
 - `REDIS_URL` (optional if redis is hosted at `localhost:6379` relative to lulu)
 - `NAMER_NAME`
 - `NAMER_NICK`

--- a/external-scripts.json
+++ b/external-scripts.json
@@ -2,5 +2,6 @@
 	"hubot-google-translate",
 	"hubot-tell",
 	"hubot-shipit",
-	"hubot-redis-brain"
+	"hubot-redis-brain",
+	"hubot-youtube"
 ]

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "hubot-scripts": "git://github.com/github/hubot-scripts.git#master",
     "hubot-shipit": "^0.2.0",
     "hubot-tell": "*",
+    "hubot-youtube": ">=1.0.1",
     "jsdom": "< 4.0.0",
     "mathjs": ">= 1.5.0",
     "ntwitter": ">= 0.5.0",


### PR DESCRIPTION
After completion of hubot-scripts/hubot-youtube#2 and hubot-scripts/hubot-youtube#3, searching YouTube now works properly! hubot-scripts/hubot-youtube#7 sets the package to version `1.0.1` and I request this package or newer for lulu.
