### PR TITLE
Add stock ticker script

### DIFF
--- a/external-scripts.json
+++ b/external-scripts.json
@@ -4,4 +4,5 @@
 	"hubot-shipit",
 	"hubot-redis-brain",
 	"hubot-youtube"
+	"hubot-scripts-stock"
 ]


### PR DESCRIPTION
Add the stock script, to allow keywords for tracking stock symbols.

This requires `npm install hubot-scripts-stock --save` to be run on the host server.
