### PR TITLE
Add environment variables link to help response

### DIFF
--- a/scripts/help.coffee
+++ b/scripts/help.coffee
@@ -70,7 +70,7 @@ module.exports = (robot) ->
       # When there is no command asked about, just tell the room where to find
       # lulu's command listing, instead of exceeding the server's flood limit
       # attempting to send a command listing.
-      msg.send "View my command list here: http://hacsoc.org/lulu"
+      msg.send "View my command list at http://hacsoc.org/lulu and my environment variables at http://hacsoc.org/lulu/env.html"
 
   robot.router.get '/hubot/help', (req, res) ->
     cmds = robot.helpCommands()


### PR DESCRIPTION
Skip having to remember `env.html` and just have lulu return the location of the environment variable documentation as well.
